### PR TITLE
fix(apiMgmtApi): Prevent 406 unacceptable

### DIFF
--- a/apiMgmtApi.js
+++ b/apiMgmtApi.js
@@ -24,6 +24,9 @@ class ApiMgmtApi {
             data: policyContent
         };
 
+        // Remove the default accept headers. Microsoft is rejecting the request with 406
+        delete axios.defaults.headers.common.accept;
+
         const result = await axios(options)
         // look up what axios considers http errors
         .catch(function (error) {


### PR DESCRIPTION
Axios by default includes an accept header which requests: json, plain text or anything.
Microsofts API has recently changed and now returns 406 unacceptable when we include this header in the request to set policies.
Removing this accept header appears to fix the problem.