### PR TITLE
fix(apiMgmtApi): Set policies fails with 'Not Acceptable'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes will be documented in this file in accordance with
 
 ## \[Unreleased]
 
+## /[2.1.1] - 2019-01-14
+
+### Fixed
+- [Set policies fails with 'Not Acceptable'](https://github.com/opspec-pkgs/azure.apimanagement.policies.set/pull/9)
+
 ## \[2.1.0] - 2018-03-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ the op uses [![opspec 0.1.5](https://img.shields.io/badge/opspec-0.1.5-brightgre
 ## Install
 
 ```shell
-opctl op install github.com/opspec-pkgs/azure.apimanagement.policies.set#2.1.0
+opctl op install github.com/opspec-pkgs/azure.apimanagement.policies.set#2.1.1
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/azure.apimanagement.policies.set#2.1.0
+opctl run github.com/opspec-pkgs/azure.apimanagement.policies.set#2.1.1
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/azure.apimanagement.policies.set#2.1.0
+  ref: github.com/opspec-pkgs/azure.apimanagement.policies.set#2.1.1
   inputs:
     apiCredentialsKey:
     apiManagementServiceName:

--- a/apiMgmtApi.js
+++ b/apiMgmtApi.js
@@ -1,6 +1,9 @@
 const msRestAzure = require('ms-rest-azure');
-const {URL} = require('url');
+const { URL } = require('url');
 const axios = require('axios');
+
+// Remove the default accept headers. Microsoft is rejecting the request with 406
+delete axios.defaults.headers.common.Accept;
 
 class ApiMgmtApi {
     async setPolicy(credentials, apiRef, policyContent) {
@@ -9,26 +12,27 @@ class ApiMgmtApi {
             `apis/${apiRef.id}/` +
             `policy` +
             '?api-version=2017-03-01');
-        
+
         const azureServiceClient = new msRestAzure.AzureServiceClient(credentials);
 
         const headers = {};
         headers['Authorization'] = `${process.env.sasToken}`;
         headers['Content-Type'] = `${process.env.contentType}`;
         headers['If-Match'] = '*';
-		
-		let options = {
+
+        const options = {
             method: 'PUT',
             url: url.href,
-			headers,
+            headers,
             data: policyContent
         };
 
+
         const result = await axios(options)
-        // look up what axios considers http errors
-        .catch(function (error) {
-            throw new Error(`error setting policy for api '${apiRef.name}'; error was: ${error.response.statusText}`);
-        });
+            // look up what axios considers http errors
+            .catch(function (error) {
+                throw new Error(`error setting policy for api '${apiRef.name}'; error was: ${error.response.statusText}`);
+            });
 
         console.log(`set policy for api '${apiRef.name}' successfully`);
     };
@@ -46,7 +50,7 @@ class ApiMgmtApi {
 
         const azureServiceClient = new msRestAzure.AzureServiceClient(credentials);
 
-        let options = {
+        const options = {
             method: 'GET',
             url: url.href,
         };

--- a/apiMgmtApi.js
+++ b/apiMgmtApi.js
@@ -6,14 +6,12 @@ const axios = require('axios');
 delete axios.defaults.headers.common.Accept;
 
 class ApiMgmtApi {
-    async setPolicy(credentials, apiRef, policyContent) {
+    async setPolicy(apiRef, policyContent) {
         const url = new URL(
             `https://${process.env.apiManagementServiceName}.management.azure-api.net/` +
             `apis/${apiRef.id}/` +
             `policy` +
             '?api-version=2017-03-01');
-
-        const azureServiceClient = new msRestAzure.AzureServiceClient(credentials);
 
         const headers = {};
         headers['Authorization'] = `${process.env.sasToken}`;

--- a/apiMgmtApiOperation.js
+++ b/apiMgmtApiOperation.js
@@ -1,6 +1,9 @@
 const msRestAzure = require('ms-rest-azure');
-const {URL} = require('url');
+const { URL } = require('url');
 const axios = require('axios');
+
+// Remove the default accept headers. Microsoft is rejecting the request with 406
+delete axios.defaults.headers.common.Accept;
 
 class ApiMgmtApiOperation {
     async setPolicy(credentials, apiRef, operationRef, policyContent) {
@@ -17,23 +20,23 @@ class ApiMgmtApiOperation {
         headers['Authorization'] = `${process.env.sasToken}`;
         headers['Content-Type'] = `${process.env.contentType}`;
         headers['If-Match'] = '*';
-		
-		let options = {
+
+        let options = {
             method: 'PUT',
             url: url.href,
-			headers,
+            headers,
             data: policyContent
         };
 
         const result = await axios(options)
-        .catch(function (error) {
-            throw new Error(`error setting policy for operation '${operationRef.name}' of api '${apiRef.name}'; error was: ${error.response.statusText}`);
-        });
+            .catch(function (error) {
+                throw new Error(`error setting policy for operation '${operationRef.name}' of api '${apiRef.name}'; error was: ${error.response.statusText}`);
+            });
 
         console.log(`set policy for operation '${operationRef.name}' of api '${apiRef.name}' successfully`);
     };
 
-    async getIdByName(credentials, apiRef, operationName){
+    async getIdByName(credentials, apiRef, operationName) {
         const url = new URL(
             'https://management.azure.com/' +
             `subscriptions/${process.env.subscriptionId}/` +
@@ -58,7 +61,7 @@ class ApiMgmtApiOperation {
         }
 
         let operationId;
-        for (let i = 0; i < result.value.length; i++ ) {
+        for (let i = 0; i < result.value.length; i++) {
             const item = result.value[i];
             if (item.properties.displayName === operationName) {
                 operationId = item.name;
@@ -66,7 +69,7 @@ class ApiMgmtApiOperation {
             }
         }
 
-        if (!operationId){
+        if (!operationId) {
             throw new Error(`no operation found w/ displayName: '${operationName}' in api '${apiRef.name}'`);
         }
 

--- a/apiMgmtProduct.js
+++ b/apiMgmtProduct.js
@@ -1,6 +1,9 @@
 const msRestAzure = require('ms-rest-azure');
-const {URL} = require('url');
+const { URL } = require('url');
 const axios = require('axios');
+
+// Remove the default accept headers. Microsoft is rejecting the request with 406
+delete axios.defaults.headers.common.Accept;
 
 class ApiMgmtProduct {
 
@@ -17,23 +20,23 @@ class ApiMgmtProduct {
         headers['Authorization'] = `${process.env.sasToken}`;
         headers['Content-Type'] = `${process.env.contentType}`;
         headers['If-Match'] = '*';
-		
-		let options = {
+
+        let options = {
             method: 'PUT',
             url: url.href,
-			headers,
+            headers,
             data: policyContent
         };
 
         const result = await axios(options)
-        .catch(function (error) {
-            throw new Error(`error setting policy for product '${productRef.name}'; error was: ${error.response.statusText}`);
-        });
+            .catch(function (error) {
+                throw new Error(`error setting policy for product '${productRef.name}'; error was: ${error.response.statusText}`);
+            });
 
         console.log(`set policy for product '${productRef.name}' successfully`);
     };
 
-    async getIdByName(credentials, productName){
+    async getIdByName(credentials, productName) {
         const url = new URL(
             'https://management.azure.com/' +
             `subscriptions/${process.env.subscriptionId}/` +
@@ -57,7 +60,7 @@ class ApiMgmtProduct {
         }
 
         let operationId;
-        for (let i = 0; i < result.value.length; i++ ) {
+        for (let i = 0; i < result.value.length; i++) {
             const item = result.value[i];
             if (item.properties.displayName === productName) {
                 operationId = item.name;
@@ -65,7 +68,7 @@ class ApiMgmtProduct {
             }
         }
 
-        if (!operationId){
+        if (!operationId) {
             throw new Error(`no product found w/ displayName: '${productName}'`);
         }
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,6 @@ const processApiDir = async (credentials, dirPath) => {
             } else if (item === POLICY_FILENAME) {
                 promises.push(
                     apiMgmtApi.setPolicy(
-                        credentials,
                         apiRef,
                         fs.readFileSync(itemAbsPath, 'utf8')
                     )

--- a/op.yml
+++ b/op.yml
@@ -66,7 +66,7 @@ inputs:
       constraints: { enum: [user, sp]}
       description: type of login; 'user' (default) or 'sp' for service principal
       default: user
-version: 2.1.0
+version: 2.1.1
 run:
   serial:
     - op:
@@ -78,7 +78,7 @@ run:
         outputs:
           sasToken:
     - container:
-        image: { ref: 'opspecpkgs/azure.apimanagement.policies.set:2.1.0' }
+        image: { ref: 'opspecpkgs/azure.apimanagement.policies.set:2.1.1' }
         cmd: [node, /index.js ]
         dirs:
           /policies: $(policies)


### PR DESCRIPTION
A recent change by Microsoft now causes this op to fail with the message Not acceptable.
We have found that axios will include the Accept header by default asking for 'application/json, text/plain, \*/\*'
We have found that removing this default header, allows the op to successfully deploy policies.